### PR TITLE
fix #21: app-switcher.fifo permissions to work around protected_fifos

### DIFF
--- a/resources/app-switcher.sh
+++ b/resources/app-switcher.sh
@@ -154,7 +154,10 @@ fs_setting=$(cat /home/osmc/.kodi/userdata/addon_data/script.launch.retropie/set
 
 # setup FIFO for communication
 if [[ ! -p $FIFO ]]; then
-  sudo -u osmc mkfifo $FIFO
+  # Recent kernels (4.19+) "disallow open of FIFOs ... not owned by the user in
+  #   world writable sticky directories"
+  # See https://kernelnewbies.org/Linux_4.19#Security
+  sudo mkfifo -m 660 $FIFO && sudo chown root:osmc $FIFO
 fi
 
 while true; do


### PR DESCRIPTION
Recent kernels (4.19+) "disallow open of FIFOs ... not owned by the user in
  world writable sticky directories"
See https://kernelnewbies.org/Linux_4.19#Security